### PR TITLE
Fix error `4012 RESTRICTIONS_CANNOT_BE_MET` for Video Futur platform

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Patrick Kunka <patrick@kunkalabs.com>
 Philo Inc. <*@philo.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Roi Lipman <roilipman@gmail.com>
+Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>
 Rostislav Hejduk <Ross-cz@users.noreply.github.com>
 SameGoal Inc. <*@samegoal.com>
 Sanborn Hilland <sanbornh@rogers.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,6 +67,7 @@ Patrick Kunka <patrick@kunkalabs.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>
+Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>
 Rostislav Hejduk <Ross-cz@users.noreply.github.com>
 Sam Dutton <dutton@google.com>
 Sanborn Hilland <sanbornh@rogers.com>

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1293,7 +1293,8 @@ shaka.media.DrmEngine = class {
       // However, unlike Edge and Chromecast, Tizen doesn't have this problem.
       if (this.currentDrmInfo_.keySystem == 'com.microsoft.playready' &&
           keyId.byteLength == 16 &&
-          !shaka.util.Platform.isTizen()) {
+          !shaka.util.Platform.isTizen() &&
+          !shaka.util.Platform.isVideoFutur()) {
         // Read out some fields in little-endian:
         const dataView = shaka.util.BufferUtils.toDataView(keyId);
         const part0 = dataView.getUint32(0, /* LE= */ true);

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -85,6 +85,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Video Futur.
+   *
+   * @return {boolean}
+   */
+  static isVideoFutur() {
+    return shaka.util.Platform.userAgentContains_('VITIS');
+  }
+
+  /**
    * Check if the current platform is a WebOS.
    *
    * @return {boolean}


### PR DESCRIPTION
For Video Futur platform, like for Tizen, key IDs should not be
transformed to big-endian UUIDs, it causes `4012
RESTRICTIONS_CANNOT_BE_MET` error.

Issue #2189